### PR TITLE
fix: ReflectionParameter::getClass deprecated since PHP 8.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true
     },
     "extra": {

--- a/src/ParameterMatcher.php
+++ b/src/ParameterMatcher.php
@@ -17,6 +17,7 @@ use Laminas\Stdlib\RequestInterface;
 use Laminas\Stdlib\ResponseInterface;
 use ReflectionException;
 use ReflectionFunction;
+use ReflectionNamedType;
 use ReflectionObject;
 
 use function count;
@@ -68,8 +69,9 @@ class ParameterMatcher
         foreach ($reflMethodParams as $reflMethodParam) {
             $paramName             = $reflMethodParam->getName();
             $normalMethodParamName = str_replace(['-', '_'], '', strtolower($paramName));
-            if ($reflectionTypehint = $reflMethodParam->getClass()) {
-                $typehint = $reflectionTypehint->getName();
+            $reflectionType        = $reflMethodParam->getType();
+            if ($reflectionType instanceof ReflectionNamedType && ! $reflectionType->isBuiltin()) {
+                $typehint = $reflectionType->getName();
 
                 if (
                     $typehint === PhpEnvironmentRequest::class


### PR DESCRIPTION
Deprecation warning fix.
https://www.php.net/manual/en/reflectionparameter.getclass.php
As documentation suggests, I replaced getClass() with getType() with further determination if it's ReflectionNamedType to avoid unions and intersections and not a builtin type.